### PR TITLE
Add missing PrelNames and THNames

### DIFF
--- a/ghc-api-compat.cabal
+++ b/ghc-api-compat.cabal
@@ -102,8 +102,8 @@ library
          , GHC.Rename.Unbound             as RnUnbound
          , GHC.Rename.Utils               as RnUtils
 
-         , GHC.Builtin.Names
-         , GHC.Builtin.Names.TH
+         , GHC.Builtin.Names              as PrelNames
+         , GHC.Builtin.Names.TH           as THNames
          , GHC.Builtin.PrimOps            as PrimOp
          , GHC.Builtin.RebindableNames
          , GHC.Builtin.Types              as TysWiredIn


### PR DESCRIPTION
I'm not sure why they were omitted, given that their new names were already explicitly mentioned in the cabal file.
Is there a reason that they shouldn't be included?